### PR TITLE
[SearchBar Component] Removing a non existing pointed ref

### DIFF
--- a/src/components/searchbar.js
+++ b/src/components/searchbar.js
@@ -15,7 +15,7 @@ export class SearchBarInput extends PureComponent {
     componentDidMount() {
         const {hasFocus, term} = this.props;
         if(hasFocus) {
-            ReactDOM.findDOMNode(this.refs.searchBarInputText.refs.htmlInput).focus();
+            ReactDOM.findDOMNode(this.refs.searchBarInputText).focus();
         }
     }
     _onInputChange(value) {


### PR DESCRIPTION
## [SearchBar Component] Removing a non existing pointed ref

### Description 

The searchbar were pointed a non existing ref, the `htmlInput` is not meant to exist